### PR TITLE
[fctlog] Lifts copyable args requirement and fixes ostream for unique…

### DIFF
--- a/samples/demo/demo.cpp
+++ b/samples/demo/demo.cpp
@@ -3,6 +3,7 @@
 
 #include "demo.h"
 #include <stdexcept>
+#include <iostream>
 
 namespace fctlog {
 
@@ -21,6 +22,11 @@ int Demo::f2(int val, const std::string &) {
     throw std::runtime_error("MyException");
   }
   return val;
+}
+
+int Demo::f3(std::unique_ptr<int>& ptr) const {
+  int retVal = *ptr;
+  return retVal;
 }
 
 int Demo::f2Const(int x, int y) const { return x + y; }

--- a/samples/demo/demo.h
+++ b/samples/demo/demo.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <string>
+#include <memory>
 
 namespace fctlog {
 
@@ -15,6 +16,7 @@ public:
   virtual int f1(int val = 0);
   virtual int f2(int val = 0, const std::string &str = "");
   virtual int f2Const(int x, int y) const;
+  virtual int f3(std::unique_ptr<int>& foo) const;
 };
 
 } // namespace fctlog

--- a/samples/demo/demolog.h
+++ b/samples/demo/demolog.h
@@ -15,6 +15,7 @@ class DemoLog : public Demo {
   FCTLOG_METHOD1(int, f1, (int val = 0), val);
   FCTLOG_METHOD2(int, f2, (int val = 0, const std::string &str = ""), val, str);
   FCTLOG_CONST_METHOD2(int, f2Const, (int x, int y), x, y);
+  FCTLOG_CONST_METHOD1(int, f3, (std::unique_ptr<int>& foo), foo);
 };
 
 } // namespace fctlog

--- a/samples/demo/main.cpp
+++ b/samples/demo/main.cpp
@@ -25,6 +25,8 @@ int main() {
     ref.f2();
     ref.f2Const(1, 2);
     ref.f2(1, "Hello");
+    std::unique_ptr<int> int_unique_ptr = std::unique_ptr<int>(new int(5));
+    ref.f3(int_unique_ptr);
     ref.f2(123, "World");
     ref.f2();
   } catch (std::exception &e) {

--- a/src/include/fctlog/functionlogger.h
+++ b/src/include/fctlog/functionlogger.h
@@ -13,13 +13,14 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 namespace fctlog {
 
 template <typename Tret, typename... Targs> class FunctionLoggerBase {
 public:
   typedef typename std::function<Tret()> Tfct;
-  FunctionLoggerBase(const std::string &className, const std::string &fctName, Tfct fct, Targs... args)
+  FunctionLoggerBase(const std::string &className, const std::string &fctName, Tfct fct, Targs const&... args)
       : function(fct) {
     fullName = className.substr(1, className.size() - 2);
     fullName.append("::");
@@ -45,12 +46,12 @@ private:
   }
 
   template <typename T, typename... Ts>
-  void getEntryMsgInternal(std::stringstream &s, T arg, Ts... args) {
+  void getEntryMsgInternal(std::stringstream &s, T const& arg, Ts const&... args) {
     s << (s.str().empty() ? "args: " : " ; ") << arg;
     getEntryMsgInternal(s, args...);
   }
 
-  template <typename... Ts> std::string getEntryMsg(Ts... args) {
+  template <typename... Ts> std::string getEntryMsg(Ts const&... args) {
     std::stringstream s;
     getEntryMsgInternal(s, args...);
     return s.str();

--- a/src/include/fctlog/ostream.h
+++ b/src/include/fctlog/ostream.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <iostream>
 #include <memory>
+#include <vector>
 
 namespace fctlog {
 
@@ -16,22 +17,30 @@ int OstreamContainerInternal<T>::maxElement = 10;
 
 struct OstreamContainer : public OstreamContainerInternal<void> {};
 
-template <template <class, class> class Container, class T, class Alloc = std::allocator <T> >
-std::ostream& operator << ( 
-std::ostream& os,
-const Container <T, Alloc> & container )
-{
-int count = 0;
-os << "[";
-for (const T& e : container) {
+template <typename PT, typename DT>
+std::ostream& operator << (
+    std::ostream& os,
+    const std::unique_ptr<PT, DT>& ptr
+) {
+  return os << reinterpret_cast<void*>(ptr.get());
+}
+
+template <typename PT, typename DT>
+std::ostream& operator << (
+    std::ostream& os,
+    const std::vector<PT, DT>& vector
+) {
+  int count = 0;
+  os << "[";
+  for (const PT& e : vector) {
     os << (count == 0 ? "" : ", ") << e;
     ++count;
     if(count >= OstreamContainer::maxElement) {
         os << ", ...";
         break;
     }
-}
-return os << "]";
+  }
+  return os << "]";
 }
 
-} // namespace fctlog    
+} // namespace fctlog


### PR DESCRIPTION
…_ptr

The args are no longer given by value but by reference into the functionlogger.
Thus it is no longer a requirement for them to be copyable.

Furthermore, the function for printing "Containers" was removed and specialized
for vector instead. The previous templating resulted in the method also matching
std::unique_ptr, which then resulted in compile errors. Additionally the previous
implementation also didn't work for any comparison based containers, like std::set.

Furthermore adds a method for printing unique_ptrs.